### PR TITLE
Extract BOM creation and push code from wire-server

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file designates code owners for different parts of the repository
+
+# Define code owners for all files in the repository
+*     @wireapp/backend @julialongtin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+# Trigger the workflow on push or pull request, but only for the master branch
+on:
+  pull_request:
+  push:
+    branches: [master]
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+# INFO: The following configuration block ensures that only one build runs per branch,
+# which may be desirable for projects with a costly build process.
+# Remove this block from the CI workflow to let each CI job run to completion.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: General linting steps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+
+      - name: nix flake check
+        run: nix flake check
+
+      - name: treefmt - check format
+        run: nix fmt -- --ci
+
+      - name: Haskell build
+        run: nix build .
+
+  bom:
+    name: Build and push the BOM of tom-bombadil itself
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v27
+
+      - name: Set tag output
+        id: vars
+        run: echo "tag_or_branch=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Check tag
+        run: echo ${TAG}
+        env:
+          TAG: ${{ steps.vars.outputs.tag_or_branch }}
+
+      - name: Build BOM dependencies
+        run: nix build .\#bomDependencies
+
+      - name: Build BOM file
+        run: nix run '.#create-sbom' -- --root-package-name "tom-bombadil"
+
+      - name: Validate BOM file
+        run: nix develop --command bash -c "cyclonedx validate --input-file sbom.json"
+
+      - name: Push BOM file
+        run: >-
+          nix run '.#upload-bom' --
+          --project-name "tom-bombadil" 
+          --project-version "$TAG" 
+          --auto-create 
+          --bom-file ./sbom.json
+        env:
+          TAG: ${{ steps.vars.outputs.tag_or_branch }}
+          DEPENDENCY_TRACK_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist-newstyle/
+.direnv/
+result/
+sbom.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # tom-bombadil
-Tom BOMbadil creates Bills-of-Materials (BOMs) and pushes them
+
+Tom BOMbadil creates Bills-of-Materials (BOMs) and pushes them.
+
+## Usage
+
+There are three steps:
+
+1. Create a JSON file with Nix meta data and a folder with links to derivations
+   of concern.
+1. Create the BOM file (`sbom.json`) from these inputs.
+1. Push (upload) the BOM file to our dependency tracking service.
+
+### 1. Create Inputs
+
+This step needs access to your Nix context. It is provided as a Nix flake
+library function.
+
+```nix
+  tom-bombadil = builtins.getFlake "git+file:///home/sven/src/tom-bombadil";
+  bomDependencies = tom-bombadil.lib.${builtins.currentSystem}.bomDependenciesDrv pkgs localPkgs haskellPackages;
+```
+
+Where
+
+- `pkgs` is the full package set (e.g. `nixpkgs`.)
+- `localPkgs` are the packages to create BOM root entries for.
+- `haskellPackages` `pkgs.haskellPackages` with overrides/overlays
+
+The derivation can than be built with e.g. (for `wire-server`):
+
+```nix
+nix -Lv build -f nix wireServer.bomDependencies
+```
+
+This leads to a `results/` folder containing the mentioned files.
+
+### 2. Create BOM file
+
+`create-sbom` is a Haskell program. To execute it on the results folder run:
+
+```shell
+nix run ../tom-bombadil\#create-sbom -- --meta result/all-toplevel.jsonl --all-local-packages result/all-local-packages
+```
+
+This leads to the SBOM json file being written to `sbom.json`.
+
+### 3. Push (upload) BOM file
+
+To upload the `sbom.json` run:
+
+```shell
+nix run ../tom-bombadil\#upload-bom -- -p my-project -v 0.1 -k $MY_API_KEY -f sbom.json
+```

--- a/app/create-sbom.hs
+++ b/app/create-sbom.hs
@@ -1,0 +1,393 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wall #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+{-
+- the only place that has the data we need about the package is the evaluated nix code, i.e. before
+  writing the derivation; this is where we have `meta` and friends to get the data we need
+- say we now want to build a dependency tree; the issue is to find all dependencies of the derivation.
+  this is hard because
+  - there are normal input attrs that the builder will have a look at but also
+  - string contexts like
+    ```nix
+    x = /* bash */ ''
+      cp ${pkgs.bla}/bin $out
+    '';
+    ```
+    would ignore dependencies on `pkgs.bla`
+- we can build the dependency graph independently (without knowing about the meta) but we somehow need
+  to obtain the meta itself
+- people don't always have a complete package set but more commonly are hand assembling things; we need
+  to give the possibility to build meta "databases" from package sets
+- we need to trace which dependencies are missing when querying the meta database against them
+- collecting the meta also poses some issue
+  - nixpkgs is not a tree, but a more general graph
+  - it also not a DAG but it has loops
+  - this means more specifically that we cannot without care recurse into it
+  - even if we only recurse very shallowly, we soon start running out of memory, this means we probably need
+    to do some on the fly filtering by "actual" dependencies
+  - this is similarly an issue, because it means that for every package we have to evaluate the entirety
+    of the package set instead of being able to keep and persist the database
+  - a more clean solution would probably be to at each time we recurse, a derivation that does the evaluation
+    and outputs a JSON that can later be read
+
+how this relates to bombon:
+- bombon uses a more coarse grained approach
+- this builds a metadata "database" i.e. is two pass
+- see the corresponding nix code in ./nix
+-}
+
+import Control.Applicative ((<|>))
+import Control.Arrow ((&&&))
+import Data.Aeson
+import Data.Aeson.Key qualified as KM
+import Data.Aeson.KeyMap qualified as KM
+import Data.Aeson.Types (typeMismatch)
+import Data.Bifunctor (first)
+import Data.Bitraversable (bitraverse)
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 qualified as C8
+import Data.ByteString.Lazy (LazyByteString)
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Lazy.Char8 qualified as C8L
+import Data.Containers.ListUtils (nubOrd, nubOrdOn)
+import Data.Functor.Identity
+import Data.Map (Map)
+import Data.Map qualified as M
+import Data.Maybe
+import Data.Proxy
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import Data.Time.Clock.POSIX
+import Data.Time.Format.ISO8601 (iso8601Show)
+import Data.Traversable (for)
+import Data.Tree
+import Data.UUID qualified as UUID
+import Data.UUID.V4 qualified as V4
+import Debug.Trace
+import GHC.Generics hiding (Meta)
+import GHC.IsList (IsList (fromList, toList))
+import Numeric.Natural (Natural)
+import Options.Applicative (customExecParser, fullDesc, help, long, prefs, progDesc, showHelpOnEmpty, strOption, value)
+import Options.Applicative qualified as Opt
+import System.Directory
+import System.Process
+
+data License = MkLicense
+  { id :: Maybe Text,
+    name :: Maybe Text
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+sadSbomMeta :: Text -> Text -> [Text] -> SBomMeta Identity
+sadSbomMeta drvPath outPath directDeps =
+  MkSBomMeta
+    { drvPath = drvPath,
+      outPath = Identity outPath,
+      directDeps = Identity directDeps,
+      description = Nothing,
+      homepage = Nothing,
+      licenseSpdxId = [],
+      name = Nothing,
+      typ = Nothing,
+      urls = [],
+      version = Nothing
+    }
+
+data SBomMeta f = MkSBomMeta
+  { drvPath :: Text,
+    description :: Maybe Text,
+    homepage :: Maybe Text,
+    licenseSpdxId :: [Maybe License],
+    name :: Maybe Text,
+    typ :: Maybe Text,
+    urls :: [Maybe Text],
+    version :: Maybe Text,
+    outPath :: f Text,
+    directDeps :: f [Text]
+  }
+
+deriving stock instance (Eq (f [Text]), Eq (f Text)) => Eq (SBomMeta f)
+
+deriving stock instance (Ord (f [Text]), Ord (f Text)) => Ord (SBomMeta f)
+
+deriving stock instance (Show (f [Text]), Show (f Text)) => Show (SBomMeta f)
+
+type Meta = SBomMeta Proxy
+
+instance FromJSON Meta where
+  parseJSON (Object val) =
+    MkSBomMeta
+      <$> do val .: "drvPath"
+      <*> do val .: "description"
+      <*> do val .: "homepage"
+      <*> do val .: "licenseSpdxId"
+      <*> do val .: "name"
+      <*> do val .: "type"
+      <*> do val .: "urls"
+      <*> do val .: "version"
+      <*> pure Proxy
+      <*> pure Proxy
+  parseJSON invalid = typeMismatch "Object" invalid
+
+type SBom = Map Text (SBomMeta Identity)
+
+type MetaDB = Map Text (SBomMeta Proxy)
+
+type ClosureInfo = Tree ByteString
+
+type PathInfo = [(Text, (Text, [Text]))]
+
+data Visit a = Seen a | Unseen a
+  deriving stock (Eq, Ord, Show)
+
+data SerializeSBom = MkSerializeSBom
+  { -- | the version of the SBom; this is version of the old SBom + 1
+    sbom'version :: Natural,
+    -- | name of the component the SBom is generated for
+    sbom'component :: Text,
+    -- | the creator of the component the SBom is generated for
+    sbom'manufacture :: Text,
+    -- | the supplier (manufacturer or repackager or distributor)
+    sbom'supplier :: Maybe Text,
+    -- | (spdxids of) licenses of the product
+    sbom'licenses :: [Text]
+  }
+
+defaultSerializeSBom :: String -> SerializeSBom
+defaultSerializeSBom component =
+  MkSerializeSBom
+    { sbom'version = 1,
+      sbom'component = T.pack component,
+      sbom'manufacture = "wire",
+      sbom'supplier = Nothing,
+      sbom'licenses = ["AGPL-3.0-or-later"]
+    }
+
+-- FUTUREWORK(mangoiv): we can also have
+--
+-- - qualifiers: extra qualifying data for a package such as an OS, architecture, a distro, etc. Optional and type-specific.
+-- - subpath: extra subpath within a package, relative to the package root. Optional.
+-- - use heuristics based approach to finding original repositories for packages, e.g. pkg:hackage....
+mkPurl :: SBomMeta Identity -> Text
+mkPurl meta =
+  mconcat
+    [ "pkg:",
+      repo,
+      "/",
+      fromMaybe (runIdentity meta.outPath) meta.name,
+      maybe "" ("@" <>) meta.version
+    ]
+  where
+    checks = meta.homepage : meta.urls
+    repo
+      | any (maybe False (T.isInfixOf "hackage.haskell.org")) checks = "hackage"
+      | otherwise = "nixpkgs"
+
+-- | serializes an SBom to JSON format
+--   conventions:
+--   - bomRef == outPath
+serializeSBom :: SerializeSBom -> SBom -> IO LazyByteString
+serializeSBom settings bom = do
+  uuid <- V4.nextRandom
+  curTime <- getCurrentTime
+  -- FUTUREWORK(mangoiv): "tools" (the tools used in the creation of the bom)
+  let mkDependencies :: SBomMeta Identity -> Array
+      mkDependencies meta =
+        [object ["ref" .= meta.outPath, "dependsOn" .= runIdentity meta.directDeps]]
+
+      serializeLicense :: Maybe License -> Maybe Value
+      serializeLicense ml = do
+        l <- ml
+        idOrName <-
+          (\i -> ["id" .= i]) <$> l.id
+            <|> (\n -> ["name" .= n]) <$> l.name
+        pure (object idOrName)
+
+      mkComponents :: SBomMeta Identity -> Array
+      mkComponents meta = do
+        let c :: Value
+            c =
+              -- FUTUREWORK(mangoiv): swid? https://www.iso.org/standard/65666.html
+              -- FUTUREWORK(mangoiv): CPE?
+              -- FUTUREWORK(mangoiv): more information in the supplier section
+              Object $
+                mconcat
+                  [ "type" .= String (fromMaybe "library" meta.typ),
+                    "bom-ref" .= String (runIdentity meta.outPath),
+                    "supplier" .= object ["url" .= nubOrd (maybeToList meta.homepage <> catMaybes meta.urls)],
+                    "name" .= String (fromMaybe (st'name $ splitStorePath $ runIdentity meta.outPath) meta.name),
+                    "version" .?= meta.version,
+                    "description" .?= meta.description,
+                    "scope" .= String "required",
+                    "licenses" .= ((\ln -> object ["license" .= ln]) <$> mapMaybe serializeLicense meta.licenseSpdxId),
+                    "purl" .= mkPurl meta
+                  ]
+        [c]
+      (dependencies, components) = foldMap (mkDependencies &&& mkComponents) bom
+
+  pure $
+    encode @Value $
+      object
+        [ "bomFormat" .= String "CycloneDX",
+          "specVersion" .= String "1.5",
+          "serialNumber" .= String ("urn:uuid:" <> UUID.toText uuid),
+          "version" .= Number (fromIntegral settings.sbom'version),
+          "metadata"
+            .= object
+              [ "timestamp" .= String (T.pack (iso8601Show curTime)),
+                "component"
+                  .= object
+                    [ "name" .= String settings.sbom'component,
+                      "type" .= String "application"
+                      -- FUTUREWORK(mangoiv): this should be a choice in the settings above
+                    ],
+                -- FUTUREWORK(mangoiv): "manufacture" can also have url
+                "manufacture" .= object ["name" .= String settings.sbom'manufacture],
+                "supplier" .= object ["name" .= String (fromMaybe settings.sbom'manufacture settings.sbom'supplier)],
+                "licenses" .= Array (fromList $ (\n -> object ["license" .= object ["id" .= String n]]) <$> settings.sbom'licenses)
+              ],
+          "components" .= Array components,
+          -- FUTUREWORK(mangoiv): services: allow to tell the program the name of the services like brig, galley, ...
+          "dependencies" .= Array dependencies
+        ]
+
+buildMetaDB :: [Meta] -> MetaDB
+buildMetaDB = foldMap \MkSBomMeta {..} -> [(drvPath, MkSBomMeta {..})]
+
+discoverSBom :: FilePath -> MetaDB -> IO SBom
+discoverSBom outP metaDb = do
+  canonicalOutP <- canonicalizePath outP
+  info <- pathInfo canonicalOutP
+  let go :: (Text, (Text, [Text])) -> IO SBom -> IO SBom
+      go (k, (deriver, deps)) = do
+        let proxyToIdentity :: SBomMeta Proxy -> SBomMeta Identity
+            proxyToIdentity (MkSBomMeta {..}) = MkSBomMeta {directDeps = Identity deps, outPath = Identity k, ..}
+        case M.lookup deriver metaDb of
+          Nothing -> \x -> do
+            T.putStrLn ("no meta found for drv: " <> deriver <> "\ntrying approximate match")
+            x >>= maybe
+              do
+                \m -> do
+                  T.putStrLn ("no approximate match found for: " <> deriver)
+                  pure $ M.insert k (sadSbomMeta deriver k deps) m
+              do \match -> pure . M.insert k (proxyToIdentity match)
+              do approximateMatch deriver metaDb
+          Just pmeta -> fmap $ M.insert k $ proxyToIdentity pmeta
+
+  foldr go mempty info
+
+data StorePath = MkStorePath
+  { st'hash :: Text,
+    st'name :: Text,
+    st'original :: Text
+  }
+  deriving stock (Eq, Ord, Show)
+
+-- >>> splitStorePath "/nix/store/m306sk6syihxp80zrr9xs8hi5mjricgh-sop-core-0.5.0.2"
+-- MkStorePath {st'hash = "m306sk6syihxp80zrr9xs8hi5mjricgh", st'name = "sop-core-0.5.0.2", st'original = "/nix/store/m306sk6syihxp80zrr9xs8hi5mjricgh-sop-core-0.5.0.2"}
+splitStorePath :: Text -> StorePath
+splitStorePath stp = do
+  let rest = T.drop (T.length "/nix/store/") stp
+      (hash, T.drop 1 -> name) = T.breakOn "-" rest
+  MkStorePath {st'original = stp, st'hash = hash, st'name = name}
+
+approximateMatch :: Text -> MetaDB -> Maybe (SBomMeta Proxy)
+approximateMatch stp db =
+  let goal = splitStorePath stp
+      metas = first splitStorePath <$> M.toList db
+   in case filter (\(m, _) -> m.st'name == goal.st'name) metas of
+        [(_stp, meta)] -> pure meta
+        _ -> Nothing
+
+parse :: IO CliOptions
+parse = customExecParser (prefs showHelpOnEmpty) do
+  Opt.info
+    do drvAndTlParser
+    do
+      mconcat
+        [ fullDesc,
+          progDesc "build an sbom from a derivation and a package set"
+        ]
+
+data CliOptions = CliOptions
+  { meta :: FilePath,
+    allLocalPackages :: FilePath,
+    rootPackageName :: String
+  }
+
+drvAndTlParser :: Opt.Parser CliOptions
+drvAndTlParser =
+  CliOptions
+    <$> strOption (long "meta" <> help "Path to meta data json file for all packages" <> value "result/all-toplevel.jsonl")
+    <*> strOption do
+      long "all-local-packages"
+        <> help "Path to a folder where all packages to investigate are symlinks"
+        <> value "result/all-local-packages"
+    <*> strOption
+      ( long "root-package-name"
+          <> help "Name of the root package in the BOM file (has no technical implications)"
+          <> value "wire-server"
+      )
+
+main :: IO ()
+main = parse >>= mainNoParse >>= BSL.writeFile "sbom.json"
+
+-- | by not always parsing, we have an easy time to call directly from haskell
+mainNoParse :: CliOptions -> IO LazyByteString
+mainNoParse CliOptions {..} = do
+  let mkMeta :: LazyByteString -> Maybe Meta
+      mkMeta = decodeStrict . BSL.toStrict
+  metaDB <- buildMetaDB . mapMaybe mkMeta . C8L.lines <$> BSL.readFile meta
+  sbom <- discoverSBom allLocalPackages metaDB
+  serializeSBom (defaultSerializeSBom rootPackageName) sbom
+
+pathInfo :: FilePath -> IO PathInfo
+pathInfo path = do
+  let nixPathInfo = proc "nix" ["path-info", path, "--json", "--recursive"]
+  withCreateProcess nixPathInfo {std_out = CreatePipe} \_in (Just out) _err _ph -> do
+    Just refs' <- decodeStrict @Value <$> C8.hGetContents out
+    let failureBecauseNixHasZeroContracts = fail "unexpected format: this may be due to the output of `nix path-info` having changed randomly lol"
+        tryFindOutpath :: Value -> IO (Key, Value)
+        tryFindOutpath val
+          | Object pc <- val,
+            Just (String k) <- KM.lookup "path" pc =
+              pure (KM.fromText k, val)
+        tryFindOutpath _ = failureBecauseNixHasZeroContracts
+    refs <- case refs' of
+      Object refs -> pure $ KM.toList refs
+      Array refs -> traverse tryFindOutpath $ toList refs
+      _ -> failureBecauseNixHasZeroContracts
+
+    let parseObj :: Value -> Maybe (Text, [Text])
+        parseObj info
+          | Object mp <- info,
+            Just (Array rs) <- KM.lookup "references" mp,
+            Just (String deriver) <- KM.lookup "deriver" mp,
+            Just rs' <- for rs \case
+              String s -> Just s
+              _ -> Nothing =
+              Just (deriver, toList rs')
+        parseObj _ = trace "could not parse object" Nothing
+    -- some heuristics based filtering
+    pure
+      -- remove derivations with the same deriver
+      . nubOrdOn (fst . snd)
+      -- remove derivations that are just docs
+      . filter ((/= "doc") . T.takeEnd 3 . fst)
+      . mapMaybe (bitraverse (pure . KM.toText) parseObj)
+      $ refs

--- a/app/upload-bom.hs
+++ b/app/upload-bom.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wall #-}
+
+import Data.Aeson
+import Data.ByteString.Base64.Lazy qualified as Base64
+import Data.ByteString.Lazy as BL
+import Data.Proxy
+import Data.Text.Lazy
+import Data.Text.Lazy.Encoding
+import GHC.Generics
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Options.Applicative
+import Servant.API
+import Servant.Client
+import System.Environment (lookupEnv)
+import System.Exit
+import System.Process
+
+data Payload = Payload
+  { bom :: Text,
+    projectName :: String,
+    projectVersion :: String,
+    autoCreate :: Bool
+  }
+  deriving (Generic, Show)
+
+instance ToJSON Payload
+
+data ApiResponse = ApiResponse
+  { token :: String
+  }
+  deriving (Generic, Show)
+
+instance FromJSON ApiResponse
+
+type DependenyTrackAPI =
+  "api"
+    :> "v1"
+    :> "bom"
+    :> ReqBody '[JSON] Payload
+    :> Header "X-Api-Key" String
+    :> Put '[JSON] ApiResponse
+
+api :: Proxy DependenyTrackAPI
+api = Proxy
+
+putBOM :: Payload -> Maybe String -> ClientM ApiResponse
+putBOM = client api
+
+data CliOptions = CliOptions
+  { opProjectName :: String,
+    opProjectVersion :: String,
+    opAutoCreate :: Bool,
+    opApiKey :: String,
+    opBomFilename :: FilePath
+  }
+  deriving (Show)
+
+cliParser :: Maybe String -> Parser CliOptions
+cliParser mbApiKey =
+  CliOptions
+    <$> strOption
+      ( long "project-name"
+          <> short 'p'
+          <> metavar "PROJECT_NAME"
+          <> value "wire-server-ci"
+      )
+    <*> strOption
+      ( long "project-version"
+          <> short 'v'
+          <> metavar "PROJECT_VERSION"
+      )
+    <*> switch
+      ( long "auto-create"
+          <> short 'c'
+      )
+    <*> apiKeyOption
+    <*> strOption
+      ( long "bom-file"
+          <> short 'f'
+          <> metavar "BOM_FILENAME"
+          <> value "sbom.json"
+      )
+  where
+    apiKeyOption :: Parser String
+    apiKeyOption = case mbApiKey of
+      Nothing ->
+        strOption
+          ( long "api-key"
+              <> short 'k'
+              <> metavar "API_KEY"
+              <> help "Either --api-key option or env variable DEPENDENCY_TRACK_API_KEY required"
+          )
+      Just apiKey ->
+        strOption
+          ( long "api-key"
+              <> short 'k'
+              <> metavar "API_KEY"
+              <> value apiKey
+          )
+
+fullCliParser :: Maybe String -> ParserInfo CliOptions
+fullCliParser mbApiKey =
+  info
+    (cliParser mbApiKey <**> helper)
+    ( fullDesc
+        <> progDesc "Upload BOM files to deptrack"
+    )
+
+main :: IO ()
+main = do
+  mbApiKey <- lookupEnv "DEPENDENCY_TRACK_API_KEY"
+  options <- execParser $ fullCliParser mbApiKey
+  manager' <- HTTP.newManager tlsManagerSettings
+
+  bom <- BL.readFile (opBomFilename options)
+  let payload =
+        Payload
+          { bom = toBase64Text bom,
+            projectName = opProjectName options,
+            projectVersion = opProjectVersion options,
+            autoCreate = opAutoCreate options
+          }
+  res <-
+    runClientM
+      (putBOM payload ((Just . opApiKey) options))
+      (mkClientEnv manager' (BaseUrl Https "deptrack.wire.link" 443 ""))
+  case res of
+    Left err -> print $ "Error: " ++ show err
+    Right res' -> print res'
+
+toBase64Text :: LazyByteString -> Text
+toBase64Text = decodeUtf8 . Base64.encode

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738172511,
+        "narHash": "sha256-v/8yB8LIy/KsySZYN6rO/f4kCEkj+fTLkzR0TaNMB+w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "762a398892576efcc76fb233befbd58c2cef59e0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,309 @@
+{
+  description = "Tom BOMbadil creates Bills-of-Materials (BOMs) and pushes them";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    ,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        haskellPackagesOverlay = {
+          overrides = self: super: {
+            tom-bombadil = super.developPackage {
+              root = ./.;
+              overrides = self: super: {
+                aeson = super.aeson_2_2_3_0;
+                hashable = pkgs.haskell.lib.doJailbreak super.hashable_1_4_7_0;
+                attoparsec-aeson = super.attoparsec-aeson_2_2_2_0;
+              };
+            };
+          };
+        };
+
+        haskellPackages = pkgs.haskellPackages.override haskellPackagesOverlay;
+
+        formatters = [
+          (pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.ormolu)
+          (pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.cabal-fmt)
+          pkgs.nixpkgs-fmt
+          pkgs.treefmt
+          pkgs.shellcheck
+        ];
+
+        treefmt-command = pkgs.writeShellApplication {
+          name = "nix-fmt-treefmt";
+          text = ''
+            exec ${pkgs.treefmt}/bin/treefmt --config-file ./treefmt.toml "$@"
+          '';
+          runtimeInputs = formatters;
+        };
+
+        statix-command = pkgs.writeShellApplication {
+          name = "statix-check";
+          runtimeInputs = [ pkgs.statix ];
+          text = ''
+            statix check ${toString ./.} || exit 1
+            echo "Statix check passed!"
+          '';
+        };
+
+        # Not all GHC versions are expected to work. However, we're providing
+        # dev envs to ease future development.
+        ghcVersions = [
+          "ghc92"
+          "ghc94"
+          "ghc96"
+          "ghc98"
+          "ghc910"
+        ];
+
+        haskellPackagesFor =
+          ghc_version: (pkgs.haskell.packages.${ghc_version}).override haskellPackagesOverlay;
+        additionalDevShells = builtins.listToAttrs (
+          map
+            (ghc_version: {
+              name = ghc_version;
+              value = (haskellPackagesFor ghc_version).shellFor {
+                packages = p: [ p.tom-bombadil ];
+                withHoogle = true;
+                buildInputs = [
+                  pkgs.ghcid
+                  pkgs.statix
+                  statix-command
+                  # We need to be careful to not rebuild HLS, because that would be expensive.
+                  (pkgs.haskell-language-server.override {
+                    supportedGhcVersions = [ (pkgs.lib.removePrefix "ghc" ghc_version) ];
+                  })
+                  pkgs.cyclonedx-cli
+                ] ++ formatters;
+              };
+            })
+            ghcVersions
+        );
+
+        toplevelDerivations =
+          pkgs: haskellPackages:
+          let
+            mk =
+              pkg:
+              pkgInfo {
+                inherit pkg;
+                inherit (pkgs) lib hostPlatform writeText;
+              };
+            out = allToplevelDerivations {
+              inherit (pkgs) lib;
+              fn = mk;
+              # more than two takes more than 32GB of RAM, so this is what
+              # we're limiting ourselves to
+              recursionDepth = 2;
+              keyFilter = k: k != "passthru";
+              # only import the package sets we want; this makes the database
+              # less copmplete but makes it so that nix doesn't get OOMkilled
+              pkgSet = {
+                inherit pkgs;
+                inherit haskellPackages;
+              };
+            };
+          in
+          pkgs.writeText "all-toplevel.jsonl" (builtins.concatStringsSep "\n" out);
+
+        # collects information about a single nixpkgs package
+        pkgInfo =
+          { lib
+          , pkg
+          , ...
+          }:
+          (
+            with builtins;
+            assert lib.isDerivation pkg;
+            let
+              # trace with reason
+              trc = info: pkg: trace (info + ": " + toString pkg);
+
+              # if thing is a list, map the function, else apply f to thing and return a singleton of
+              # it
+              mapOrSingleton = f: x: if isList x then map f x else [ (f x) ];
+
+              # things to save from the src attr (the derivation that was created by a fetcher)
+              srcInfo = {
+                urls = (pkg.src.urls or (trc "package didn't have src or url" pkg [ ])) ++ [
+                  (pkg.src.url or null)
+                ];
+              };
+
+              dp = builtins.tryEval pkg.drvPath;
+
+              # things to save from the meta attr
+              metaInfo =
+                let
+                  m = pkg.meta or (trc "package didn't have meta" pkg { });
+                in
+                {
+                  homepage = m.homepage or (trc "package didn't have homepage" pkg null);
+                  description = m.description or (trc "package didn't have description" pkg null);
+                  licenseSpdxId = mapOrSingleton
+                    (l: {
+                      id = l.spdxId or (trc "package license doesn't have a spdxId" pkg null);
+                      name = l.fullName or (trc "package license doens't have a name" pkg null);
+                    })
+                    (m.license or (trc "package does not have a license" pkg null));
+
+                  # based on heuristics, figure out whether something is an application for now this only checks whether this
+                  # componnent has a main program
+                  type = if m ? mainProgram then "application" else "library";
+
+                  name = pkg.pname or pkg.name or (trc "name is missing" pkg null);
+                  version = pkg.version or (trc "version is missing" pkg null);
+                };
+            in
+            if dp.success then
+              let
+                info = builtins.toJSON (
+                  srcInfo // metaInfo // { drvPath = builtins.unsafeDiscardStringContext dp.value; }
+                );
+              in
+              info
+            else
+              trc "drvPath of package could not be computed" pkg { }
+          );
+
+        # this tries to recurse into pkgs to collect metadata about packages within nixpkgs
+        # it needs a recusionDepth, because pkgs is actually not a tree but a graph so you
+        # will go around in circles; also it helps bounding the memory needed to build this
+        # we also pass a keyFilter to ignore certain package names
+        # else, this just goes through the packages, tries to evaluate them, if that succeeds
+        # it goes on and remembers their metadata
+        # there's a lot of obfuscation caused by the fact that everything needs to be tryEval'd
+        # reason being that there's not a single thing in nixpkgs that is reliably evaluatable
+        allToplevelDerivations =
+          { lib
+          , pkgSet
+          , fn
+          , recursionDepth
+          , keyFilter
+          ,
+          }:
+          (
+            let
+              go =
+                depth: set':
+                let
+                  evaluateableSet = builtins.tryEval set';
+                in
+                if evaluateableSet.success && builtins.isAttrs evaluateableSet.value then
+                  let
+                    set = evaluateableSet.value;
+                  in
+                  (
+                    if (builtins.tryEval (lib.isDerivation set)).value then
+                      let
+                        meta = builtins.tryEval (fn set);
+                      in
+                      builtins.deepSeq meta (
+                        builtins.trace ("reached leaf: " + toString set) (
+                          if meta.success then [ meta.value ] else builtins.trace "package didn't evaluate" [ ]
+                        )
+                      )
+                    else if depth >= recursionDepth then
+                      builtins.trace ("max depth of " + toString recursionDepth + " reached") [ ]
+                    else
+                      let
+                        attrVals = builtins.tryEval (builtins.attrValues (lib.filterAttrs (k: _v: keyFilter k) set));
+                        go' =
+                          d: s:
+                          let
+                            gone' = builtins.tryEval (go d s);
+                          in
+                          if gone'.success then gone'.value else builtins.trace "could not recurse because of eval error" [ ];
+                      in
+                      if attrVals.success then
+                        (builtins.concatMap
+                          (go' (
+                            builtins.trace ("depth was: " + toString depth) (depth + 1)
+                          ))
+                          attrVals.value)
+                      else
+                        builtins.trace "could not evaluate attr values because of eval error" [ ]
+                  )
+                else
+                  builtins.trace "could not evaluate package or package was not an attrset" [ ];
+            in
+            go 0 pkgSet
+          );
+        pkgsAsSymlinks =
+          allLocalPackages:
+          pkgs.symlinkJoin {
+            name = "all-local-packages";
+            paths = allLocalPackages;
+          };
+      in
+      {
+        packages = {
+          default = haskellPackages.tom-bombadil;
+          bomDependencies = self.lib.${system}.bomDependenciesDrv
+            pkgs [ haskellPackages.tom-bombadil ]
+            haskellPackages;
+        };
+
+        apps = {
+          create-sbom = {
+            type = "app";
+            program = "${haskellPackages.tom-bombadil}/bin/create-sbom";
+          };
+          upload-bom = {
+            type = "app";
+            program = "${haskellPackages.tom-bombadil}/bin/upload-bom";
+          };
+        };
+
+        # Development shell with required dependencies
+        devShells = {
+          default = additionalDevShells.ghc96;
+        } // additionalDevShells;
+
+        formatter = treefmt-command;
+
+        checks = {
+          statix =
+            pkgs.runCommand "statix-check"
+              {
+                buildInputs = [ statix-command ];
+              }
+              ''
+                statix-check > $out
+              '';
+        };
+
+        lib = rec {
+          bomDependenciesDrv =
+            allPkgs: allLocalPackages: haskellPackages:
+            pkgs.stdenv.mkDerivation (finalAttrs: {
+              pname = "BOM dependencies";
+              version = "0.1";
+
+              src = ./.;
+
+              buildPhase = ''
+                mkdir -p $out
+
+                cp ${toplevelDerivations allPkgs haskellPackages} $out/all-toplevel.jsonl
+
+                ls ${pkgsAsSymlinks allLocalPackages}
+                mkdir -p $out/all-local-packages
+                cp -r ${pkgsAsSymlinks allLocalPackages}/* $out/all-local-packages
+              '';
+            });
+        };
+      }
+    );
+}

--- a/test-create-sbom-json.sh
+++ b/test-create-sbom-json.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+nix build -f test.nix -vv
+nix run .\#create-sbom -- --meta result/all-toplevel.jsonl --all-local-packages result/all-local-packages --root-package-name "ShellCheck"
+
+nix develop --command bash -c "cyclonedx validate --input-file sbom.json"

--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,12 @@
+# Run e.g. with `nix build -f test.nix -vv`
+#
+# This example provides a meta data file and a derivation symlink directory for
+# `ShellCheck` (shell script linter written in Haskell.)
+let
+  pkgs = import <nixpkgs> { };
+  tom-bombadil = builtins.getFlake (toString ./.);
+in
+tom-bombadil.lib.${builtins.currentSystem}.bomDependenciesDrv pkgs [
+  pkgs.haskellPackages.ShellCheck
+]
+  pkgs.haskellPackages

--- a/tom-bombadil.cabal
+++ b/tom-bombadil.cabal
@@ -1,0 +1,52 @@
+cabal-version: 3.4
+name:          tom-bombadil
+version:       0.1.0.0
+synopsis:
+  Tom BOMbadil creates Bills-of-Materials (BOMs) and pushes them
+
+homepage:      https://github.com/wireapp/tom-bombadil
+author:        Sven Tennie
+maintainer:    sven.tennie@wire.com
+copyright:     (c) 2025 Wire Swiss GmbH
+license:       AGPL-3.0-only
+license-file:  LICENSE
+build-type:    Simple
+
+common warnings
+  ghc-options: -Wwarn
+
+executable create-sbom
+  import:           warnings
+  main-is:          create-sbom.hs
+  hs-source-dirs:   app/
+  default-language: GHC2021
+  build-depends:
+    , aeson                 ^>=2.2.3.0
+    , base
+    , bytestring
+    , containers
+    , directory
+    , optparse-applicative
+    , process
+    , text
+    , time
+    , uuid
+
+executable upload-bom
+  import:           warnings
+  main-is:          upload-bom.hs
+  hs-source-dirs:   app/
+  default-language: GHC2021
+  build-depends:
+    , aeson                 ^>=2.2.3.0
+    , base
+    , base64-bytestring
+    , bytestring
+    , http-client
+    , http-client-tls
+    , http-types
+    , optparse-applicative
+    , process
+    , servant
+    , servant-client
+    , text

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,26 @@
+# One CLI to format the code tree - https://github.com/numtide/treefmt
+
+[formatter.nix]
+command = "nixpkgs-fmt"
+includes = ["*.nix"]
+
+[formatter.cabal-fmt]
+command = "cabal-fmt"
+options = [ "--inplace" ]
+includes = [ "*.cabal" ]
+excludes = [
+  "dist-newstyle/"
+]
+
+[formatter.haskell]
+command = "ormolu"
+options = [
+  "--mode", "inplace",
+  "--check-idempotence",
+]
+includes = ["*.hs"]
+excludes = []
+
+[formatter.shellcheck]
+command = "shellcheck"
+includes = ["*.sh"]


### PR DESCRIPTION
The approach is far from perfect, but works for us for now.

Major improvements:

- Provided by a Nix flake interface (re-usable)
- Haskell tools are built and developed in a Cabal project
- CI pipeline to lint and check the code
- Documentation and example explain usage
- Building the BOM file and pushing it is done in two separate commands
  (easier to test)

And, we gain more separation of concerns / less duplication in other projects' Nix code.

Ticket: https://wearezeta.atlassian.net/browse/WPB-15645